### PR TITLE
Some improvements for testing

### DIFF
--- a/.github/workflows/ci_qt6_win_mac_test.yaml
+++ b/.github/workflows/ci_qt6_win_mac_test.yaml
@@ -1,0 +1,267 @@
+name: Qt6 test builds CI
+
+# TODO: revise cache usage, we don't care about it too much now.
+
+on: [pull_request, push]
+
+env:
+  VCPKG_COMMIT: b361c2eefa3966cb7cec45275aff32e90430aaa6
+  VCPKG_DEST_MACOS: /Users/runner/qbt_tools/vcpkg
+  VCPKG_DEST_WIN: C:\qbt_tools\vcpkg
+  # default features include zstd, which must be excluded until https://bugreports.qt.io/browse/QTBUG-93604 is fixed
+  # see the related comment in the main CMakeLists.txt for more information.
+  QTBASE_FEATURES: "[brotli,concurrent,core,dbus,doubleconversion,freetype,gui,harfbuzz,icu,jpeg,network,openssl,pcre2,png,sql,sql-psql,sql-sqlite,testlib,widgets]"
+
+jobs:
+
+  ci_windows_static:
+    name: Windows + vcpkg
+
+    strategy:
+      matrix:
+        build_type: ["Release", "Debug"]
+      fail-fast: false
+
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+
+    # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
+    - name: install additional required packages with chocolatey
+      run: |
+        choco install ninja
+
+    - name: setup vcpkg (cached, if possible)
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
+        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+        setupOnly: true
+        doNotCache: true
+
+    # clear buildtrees after each package installation to reduce disk space requirements
+    - name: install dependencies via vcpkg
+      run: |
+        $packages = `
+          "boost-circular-buffer:x64-windows-static",
+          "libtorrent:x64-windows-static",
+          "qtbase${{ env.QTBASE_FEATURES }}:x64-windows-static",
+          "qtsvg:x64-windows-static",
+          "qttools:x64-windows-static",
+          "qttranslations:x64-windows-static"
+        ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
+            --no-dry-run `
+            --host-triplet=x64-windows-static
+        foreach($package in $packages)
+        {
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
+            --clean-after-build `
+            --host-triplet=x64-windows-static
+        }
+
+    # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
+    - name: setup devcmd
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: build qBittorrent (${{ matrix.build_type }})
+      shell: cmd
+      run: |
+        cmake -B build -G "Ninja" ^
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+          -DVERBOSE_CONFIGURE=ON ^
+          -DMSVC_RUNTIME_DYNAMIC=OFF ^
+          --graphviz=build\target_graph.dot
+        cmake --build build
+
+    - name: install qBittorrent
+      run: |
+        cmake --install build --prefix qBittorrent_x64-windows-static_${{ matrix.build_type }}
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: qBittorrent-CI_Windows-x64-static
+        path: |
+          build/compile_commands.json
+          build/install_manifest.txt
+          build/target_graph.dot
+          qBittorrent_x64-windows-static_${{ matrix.build_type }}
+
+  ci_windows_dynamic:
+    name: Windows (dynamic) + vcpkg
+
+    strategy:
+      matrix:
+        build_type: ["Release", "Debug"]
+      fail-fast: false
+
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+
+    # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
+    - name: install additional required packages with chocolatey
+      run: |
+        choco install ninja
+
+    - name: setup vcpkg (cached, if possible)
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgDirectory: ${{ env.VCPKG_DEST_WIN }}
+        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+        setupOnly: true
+        appendedCacheKey: x64-windows-dynamic_${{ matrix.build_type }}
+
+    # clear buildtrees after each package installation to reduce disk space requirements
+    - name: install dependencies via vcpkg
+      run: |
+        $packages = `
+          "boost-circular-buffer:x64-windows",
+          "libtorrent:x64-windows",
+          "qtbase${{ env.QTBASE_FEATURES }}:x64-windows",
+          "qtsvg:x64-windows",
+          "qttools:x64-windows",
+          "qttranslations:x64-windows"
+        ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe upgrade `
+            --no-dry-run `
+            --host-triplet=x64-windows
+        foreach($package in $packages)
+        {
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg.exe install $package `
+            --clean-after-build `
+            --host-triplet=x64-windows
+        }
+
+    # NOTE: this is necessary to correctly find and use cl.exe with the Ninja generator for now
+    - name: setup devcmd
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: build qBittorrent (${{ matrix.build_type }})
+      shell: cmd
+      run: |
+        cmake -B build -G "Ninja" ^
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_WIN }}\scripts\buildsystems\vcpkg.cmake ^
+          -DVCPKG_TARGET_TRIPLET=x64-windows ^
+          -DVERBOSE_CONFIGURE=ON ^
+          -DMSVC_RUNTIME_DYNAMIC=ON ^
+          --graphviz=build\target_graph.dot
+        cmake --build build
+
+    - name: install qBittorrent
+      run: |
+        cmake --install build --prefix qBittorrent_x64-windows_${{ matrix.build_type }}
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: qBittorrent-CI_Windows-x64-dynamic
+        path: |
+          build/compile_commands.json
+          build/install_manifest.txt
+          build/target_graph.dot
+          qBittorrent_x64-windows_${{ matrix.build_type }}
+
+  ci_macos:
+    name: macOS + vcpkg
+
+    strategy:
+      matrix:
+        qbt_gui: ["GUI=ON", "GUI=OFF"]
+      fail-fast: false
+
+    runs-on: macos-10.15
+
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+
+    # - ninja is needed for building qBittorrent (because it's preferable, not a hard requirement)
+    # - automake is needed for the installation the vcpkg installation of fontconfig, a dependency of qt5-base
+    - name: install additional required packages with homebrew
+      shell: bash
+      run: |
+        brew install automake ninja
+
+    - name: setup vcpkg (cached, if possible)
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgDirectory: ${{ env.VCPKG_DEST_MACOS }}
+        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
+        setupOnly: true
+        appendedCacheKey: x64-osx-relonly
+
+    - name: configure vcpkg triplet overlay for release builds only
+      run: |
+        New-Item -Path ${{ github.workspace }} -Name "triplets_overlay" -ItemType Directory
+        Copy-Item ${{ env.RUNVCPKG_VCPKG_ROOT }}/triplets/x64-osx.cmake `
+          ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake
+        Add-Content ${{ github.workspace }}/triplets_overlay/x64-osx-release.cmake `
+          -Value "set(VCPKG_BUILD_TYPE release)","set(VCPKG_OSX_DEPLOYMENT_TARGET 10.15)"
+
+    # NOTE: Avoids a libtorrent ABI issue. See https://github.com/arvidn/libtorrent/issues/4965
+    - name: force AppleClang to compile libtorrent with the same C++ standard as qBittorrent
+      run: |
+        (Get-Content -path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake).Replace( `
+          '${FEATURE_OPTIONS}', '${FEATURE_OPTIONS} -DCMAKE_CXX_STANDARD=17') `
+          | Set-Content -Path ${{ env.RUNVCPKG_VCPKG_ROOT }}/ports/libtorrent/portfile.cmake
+
+    - name: install dependencies via vcpkg
+      run: |
+        $packages = `
+          "boost-circular-buffer:x64-osx-release",
+          "libtorrent:x64-osx-release",
+          "qtbase${{ env.QTBASE_FEATURES }}:x64-osx-release",
+          "qtsvg:x64-osx-release",
+          "qttools:x64-osx-release",
+          "qttranslations:x64-osx-release"
+        ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg upgrade `
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --host-triplet=x64-osx-release `
+            --no-dry-run
+        foreach($package in $packages)
+        {
+          ${{ env.RUNVCPKG_VCPKG_ROOT }}/vcpkg install $package `
+            --overlay-triplets=${{ github.workspace }}/triplets_overlay `
+            --host-triplet=x64-osx-release `
+            --clean-after-build
+        }
+
+    - name: build qBittorrent
+      shell: bash
+      run: |
+        cmake -B build -G "Ninja" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_DEST_MACOS }}/scripts/buildsystems/vcpkg.cmake \
+          -DVCPKG_TARGET_TRIPLET=x64-osx-release \
+          -D${{ matrix.qbt_gui }} \
+          -DVERBOSE_CONFIGURE=ON \
+          --graphviz=build/target_graph.dot
+        cmake --build build
+
+    - name: upload artifact as zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: qBittorrent-CI_macOS_${{ matrix.qbt_gui }}
+        path: |
+          build/compile_commands.json
+          build/target_graph.dot
+          build/qbittorrent.app
+          build/qbittorrent-nox.app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(qBittorrent
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 # version requirements - older vesions may work, but you are on your own
 set(minBoostVersion 1.65)
-set(minQtVersion 5.14)
+set(minQtVersion 6.1)
 set(minOpenSSLVersion 1.1.1)
 set(minLibtorrentVersion 1.2.13)
 set(minZlibVersion 1.2.11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR) # Policies <= CMP0097 default to NEW
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR) # Configurable policies: up to and including CMP0120
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 project(qBittorrent
     DESCRIPTION "The qBittorrent BitTorrent client"
@@ -9,16 +9,17 @@ project(qBittorrent
 )
 
 # use CONFIG mode first in find_package
+# TODO: compatibility with Qt6's ZSTD support is broken until https://bugreports.qt.io/browse/QTBUG-93604 is resolved
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 # version requirements - older vesions may work, but you are on your own
 set(minBoostVersion 1.65)
-set(minQtVersion 6.1)
+set(minQtVersion 6.1.1)
 set(minOpenSSLVersion 1.1.1)
-set(minLibtorrentVersion 1.2.13)
+set(minLibtorrentVersion 1.2.14)
 set(minZlibVersion 1.2.11)
 
 # features (some are platform-specific)
-include(CheckCXXSourceCompiles) # TODO: migrate to CheckSourceCompiles in CMake >= 3.19
+include(CheckSourceCompiles)
 include(FeatureSummary)
 include(FeatureOptionsSetup)
 feature_option(STACKTRACE "Enable stacktraces" ON)
@@ -35,7 +36,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         OFF "NOT GUI" OFF
     )
     if (STACKTRACE)
-        check_cxx_source_compiles(
+        check_source_compiles(
+            CXX
             "#include <execinfo.h>
             int main(){return 0;}"
             QBITTORRENT_HAS_EXECINFO_H

--- a/dist/unix/CMakeLists.txt
+++ b/dist/unix/CMakeLists.txt
@@ -10,46 +10,46 @@ if (SYSTEMD)
             )
         endif()
     endif()
-    set(EXPAND_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
-    configure_file(systemd/qbittorrent-nox@.service.in ${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service @ONLY)
+    set(EXPAND_BINDIR "${CMAKE_INSTALL_FULL_BINDIR}")
+    configure_file(systemd/qbittorrent-nox@.service.in "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/qbittorrent-nox@.service"
-        DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}
+        DESTINATION "${SYSTEMD_SERVICES_INSTALL_DIR}"
         COMPONENT data
     )
 endif()
 
 if (GUI)
-    list(APPEND MAN_FILES ${PROJECT_SOURCE_DIR}/doc/qbittorrent.1)
+    list(APPEND MAN_FILES_LIST "${PROJECT_SOURCE_DIR}/doc/qbittorrent.1")
 else()
-    list(APPEND MAN_FILES ${PROJECT_SOURCE_DIR}/doc/qbittorrent-nox.1)
+    list(APPEND MAN_FILES_LIST "${PROJECT_SOURCE_DIR}/doc/qbittorrent-nox.1")
 endif()
 
-install(FILES ${MAN_FILES}
-    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+install(FILES ${MAN_FILES_LIST}
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
     COMPONENT doc
 )
 
 if (GUI)
     install(FILES org.qbittorrent.qBittorrent.desktop
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications/
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
         COMPONENT data
     )
 
     install(FILES org.qbittorrent.qBittorrent.appdata.xml
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo/
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
         COMPONENT data
     )
 
     install(DIRECTORY menuicons/
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor"
         COMPONENT data
     )
 
     install(FILES
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray.svg
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-dark.svg
-        ${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray.svg"
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-dark.svg"
+        "${PROJECT_SOURCE_DIR}/src/icons/qbittorrent-tray-light.svg"
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/status"
         COMPONENT data
     )
 endif()

--- a/dist/windows/CMakeLists.txt
+++ b/dist/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
 install(FILES qt.conf
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    DESTINATION "."
     COMPONENT runtime
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,11 +35,11 @@ set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
 find_package(Boost ${minBoostVersion} REQUIRED)
 find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
 find_package(ZLIB ${minZlibVersion} REQUIRED)
-find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)
+find_package(Qt6 ${minQtVersion} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)
 if (DBUS)
-    find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS DBus)
-    set_package_properties(Qt5DBus PROPERTIES
-        DESCRIPTION "Qt5 module for inter-process communication over the D-Bus protocol"
+    find_package(Qt6 ${minQtVersion} REQUIRED COMPONENTS DBus)
+    set_package_properties(Qt6DBus PROPERTIES
+        DESCRIPTION "Qt6 module for inter-process communication over the D-Bus protocol"
         PURPOSE "Required by the DBUS feature"
     )
 endif()
@@ -60,10 +60,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(base)
 
 if (GUI)
-    find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS Widgets Svg)
-    if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        find_package(Qt5 ${minQtVersion} REQUIRED COMPONENTS WinExtras)
-    endif()
+    find_package(Qt6 ${minQtVersion} REQUIRED COMPONENTS Widgets Svg)
     add_subdirectory(gui)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (UNIX AND (NOT APPLE) AND (NOT CYGWIN))
-    find_package(LibtorrentRasterbar QUIET ${minLibtorrentVersion} COMPONENTS torrent-rasterbar)
+    find_package(LibtorrentRasterbar QUIET "${minLibtorrentVersion}" COMPONENTS torrent-rasterbar)
     if (NOT LibtorrentRasterbar_FOUND)
         include(FindPkgConfig)
         pkg_check_modules(LIBTORRENT_RASTERBAR IMPORTED_TARGET GLOBAL "libtorrent-rasterbar>=${minLibtorrentVersion}")
@@ -28,16 +28,16 @@ if (UNIX AND (NOT APPLE) AND (NOT CYGWIN))
         set_package_properties(LibtorrentRasterbar PROPERTIES TYPE REQUIRED)
     endif()
 else()
-    find_package(LibtorrentRasterbar ${minLibtorrentVersion} REQUIRED COMPONENTS torrent-rasterbar)
+    find_package(LibtorrentRasterbar "${minLibtorrentVersion}" REQUIRED COMPONENTS torrent-rasterbar)
 endif()
 # force variable type so that it always shows up in ccmake/cmake-gui frontends
 set_property(CACHE LibtorrentRasterbar_DIR PROPERTY TYPE PATH)
-find_package(Boost ${minBoostVersion} REQUIRED)
-find_package(OpenSSL ${minOpenSSLVersion} REQUIRED)
-find_package(ZLIB ${minZlibVersion} REQUIRED)
-find_package(Qt6 ${minQtVersion} REQUIRED COMPONENTS Core Network Sql Xml LinguistTools)
+find_package(Boost "${minBoostVersion}" REQUIRED)
+find_package(OpenSSL "${minOpenSSLVersion}" REQUIRED)
+find_package(ZLIB "${minZlibVersion}" REQUIRED)
+find_package(Qt6 "${minQtVersion}" REQUIRED COMPONENTS Core LinguistTools Network Sql Tools Xml)
 if (DBUS)
-    find_package(Qt6 ${minQtVersion} REQUIRED COMPONENTS DBus)
+    find_package(Qt6 "${minQtVersion}" REQUIRED COMPONENTS DBus)
     set_package_properties(Qt6DBus PROPERTIES
         DESCRIPTION "Qt6 module for inter-process communication over the D-Bus protocol"
         PURPOSE "Required by the DBUS feature"
@@ -55,7 +55,7 @@ include(MacroQbtCommonConfig)
 qbt_common_config()
 
 # include directories - ideally, would be done per target instead of global directory scope
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_subdirectory(base)
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -4,14 +4,14 @@
 # Based on https://gist.github.com/giraldeau/546ba5512a74dfe9d8ea0862d66db412
 file(GLOB QBT_TS_FILES "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
 set_source_files_properties(${QBT_TS_FILES} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
-qt5_add_translation(QBT_QM_FILES ${QBT_TS_FILES} OPTIONS -silent)
+qt6_add_translation(QBT_QM_FILES ${QBT_TS_FILES} OPTIONS -silent)
 configure_file("${qBittorrent_SOURCE_DIR}/src/lang/lang.qrc" "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" COPYONLY)
 
 if (WEBUI)
     file(GLOB QBT_WEBUI_TS_FILES "${qBittorrent_SOURCE_DIR}/src/webui/www/translations/*.ts")
     set_source_files_properties(${QBT_WEBUI_TS_FILES}
         PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/webui/www/translations")
-    qt5_add_translation(QBT_WEBUI_QM_FILES ${QBT_WEBUI_TS_FILES} OPTIONS -silent)
+    qt6_add_translation(QBT_WEBUI_QM_FILES ${QBT_WEBUI_TS_FILES} OPTIONS -silent)
     configure_file("${qBittorrent_SOURCE_DIR}/src/webui/www/translations/webui_translations.qrc"
         "${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc" COPYONLY)
 endif()
@@ -139,7 +139,7 @@ endif()
 if (GUI)
     target_link_libraries(qbt_app PRIVATE qbt_gui)
     if ((CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-        qt_import_plugins(qbt_app INCLUDE Qt5::QSvgIconPlugin Qt5::QSvgPlugin)
+        qt_import_plugins(qbt_app INCLUDE Qt6::QSvgIconPlugin Qt6::QSvgPlugin)
     endif()
 endif()
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -2,23 +2,23 @@
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
 # Based on https://gist.github.com/giraldeau/546ba5512a74dfe9d8ea0862d66db412
-file(GLOB QBT_TS_FILES "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
-set_source_files_properties(${QBT_TS_FILES} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
-qt6_add_translation(QBT_QM_FILES ${QBT_TS_FILES} OPTIONS -silent)
+file(GLOB QBT_TS_FILES_LIST "${qBittorrent_SOURCE_DIR}/src/lang/*.ts")
+set_source_files_properties(${QBT_TS_FILES_LIST} PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/lang")
+qt6_add_translation(QBT_QM_FILES_LIST ${QBT_TS_FILES_LIST} OPTIONS -silent)
 configure_file("${qBittorrent_SOURCE_DIR}/src/lang/lang.qrc" "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" COPYONLY)
 
 if (WEBUI)
-    file(GLOB QBT_WEBUI_TS_FILES "${qBittorrent_SOURCE_DIR}/src/webui/www/translations/*.ts")
-    set_source_files_properties(${QBT_WEBUI_TS_FILES}
+    file(GLOB QBT_WEBUI_TS_FILES_LIST "${qBittorrent_SOURCE_DIR}/src/webui/www/translations/*.ts")
+    set_source_files_properties(${QBT_WEBUI_TS_FILES_LIST}
         PROPERTIES OUTPUT_LOCATION "${qBittorrent_BINARY_DIR}/src/webui/www/translations")
-    qt6_add_translation(QBT_WEBUI_QM_FILES ${QBT_WEBUI_TS_FILES} OPTIONS -silent)
+    qt6_add_translation(QBT_WEBUI_QM_FILES_LIST ${QBT_WEBUI_TS_FILES_LIST} OPTIONS -silent)
     configure_file("${qBittorrent_SOURCE_DIR}/src/webui/www/translations/webui_translations.qrc"
         "${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc" COPYONLY)
 endif()
 
-FILE(GLOB QT_TRANSLATIONS "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qtbase_*.qm")
+FILE(GLOB QT_TRANSLATIONS_LIST "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qtbase_*.qm")
 foreach(EXTRA_TRANSLATION IN ITEMS "fa" "gl" "lt" "pt" "sl" "sv" "zh_CN")
-    list(APPEND QT_TRANSLATIONS "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qt_${EXTRA_TRANSLATION}.qm")
+    list(APPEND QT_TRANSLATIONS_LIST "${qBittorrent_SOURCE_DIR}/dist/qt-translations/qt_${EXTRA_TRANSLATION}.qm")
 endforeach()
 
 # Executable target configuration
@@ -47,7 +47,7 @@ target_sources(qbt_app PRIVATE
     # resources
     "${qBittorrent_SOURCE_DIR}/src/icons/icons.qrc"
     "${qBittorrent_SOURCE_DIR}/src/searchengine/searchengine.qrc"
-    ${QBT_QM_FILES}
+    ${QBT_QM_FILES_LIST}
     "${qBittorrent_BINARY_DIR}/src/lang/lang.qrc" # yes, it's supposed to be "*_BINARY_DIR"
 )
 
@@ -65,7 +65,7 @@ endif()
 # Additional platform specific configuration
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
-set_source_files_properties(${QT_TRANSLATIONS} PROPERTIES MACOSX_PACKAGE_LOCATION translations)
+set_source_files_properties(${QT_TRANSLATIONS_LIST} PROPERTIES MACOSX_PACKAGE_LOCATION translations)
 set_source_files_properties(
     "${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf"
     "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns"
@@ -78,26 +78,90 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # provide variables for substitution in dist/mac/Info.plist
     get_target_property(EXECUTABLE_NAME qbt_app OUTPUT_NAME)
     # This variable name should be changed once qmake is no longer used. Refer to the discussion in PR #14813
-    set(MACOSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET})
+    set(MACOSX_DEPLOYMENT_TARGET "${CMAKE_OSX_DEPLOYMENT_TARGET}")
     set_target_properties(qbt_app PROPERTIES
         MACOSX_BUNDLE ON
         MACOSX_BUNDLE_BUNDLE_NAME "qBittorrent"
-        MACOSX_BUNDLE_INFO_PLIST ${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist
+        MACOSX_BUNDLE_INFO_PLIST "${qBittorrent_SOURCE_DIR}/dist/mac/Info.plist"
     )
     target_sources(qbt_app PRIVATE
-        ${QT_TRANSLATIONS}
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns
-        ${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns
+        ${QT_TRANSLATIONS_LIST}
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qt.conf"
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qBitTorrentDocument.icns"
+        "${qBittorrent_SOURCE_DIR}/dist/mac/qbittorrent_mac.icns"
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set_target_properties(qbt_app PROPERTIES WIN32_EXECUTABLE ON)
     if (MINGW)
-        target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent_mingw.rc)
+        target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent_mingw.rc")
     else()
-        target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent.rc)
+        target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.rc")
     endif()
-    target_sources(qbt_app PRIVATE ${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest)
+    target_sources(qbt_app PRIVATE "${qBittorrent_SOURCE_DIR}/src/qbittorrent.exe.manifest")
+
+    # Copy DLLs to the build folder after the build, so that the executable can be run from there.
+    # When using vcpkg, everything is automatically copied except for some stuff handled by windeployqt;
+    # this is no problem because the copy_if_different command is idempotent in this case
+    # TODO: works for MSVC, what about MinGW?
+    # TODO: This can probably be greatly simplified by using TARGET_RUNTIME_DLLS instead, in CMake >= 3.21
+    if (MSVC_RUNTIME_DYNAMIC)
+        # Must manually find these DLLs, because the target names for these libs point at the .lib files, not the .dll files
+        # Handling zlib is trickier than OpenSSL because FindZLIB sucks
+        cmake_path(SET OPENSSL_DLLS_PATH "${OPENSSL_CRYPTO_LIBRARY}")
+        cmake_path(GET OPENSSL_DLLS_PATH PARENT_PATH OPENSSL_DLLS_PATH)
+        cmake_path(SET OPENSSL_DLLS_PATH NORMALIZE "${OPENSSL_DLLS_PATH}/../bin")
+        find_file(OPENSSL_LIBSSL_DLL "libssl-1_1-x64.dll" PATHS "${OPENSSL_DLLS_PATH}" DOC "OpenSSL::SSL DLL path" REQUIRED
+            NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+        )
+        find_file(OPENSSL_LIBCRYPTO_DLL "libcrypto-1_1-x64.dll" PATHS "${OPENSSL_DLLS_PATH}" DOC "OpenSSL::Crypto DLL path" REQUIRED
+            NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+        )
+        list(APPEND ZLIB_NAMES_LIST "z.dll" "zlib.dll" "zdll.dll" "zlib1.dll" "zd.dll" "zlibd.dll" "zdlld.dll" "zlibd1.dll" "zlib1d.dll")
+        get_target_property(ZLIB_RELEASE_LOCATION ZLIB::ZLIB IMPORTED_LOCATION_RELEASE)
+        get_target_property(ZLIB_DEBUG_LOCATION ZLIB::ZLIB IMPORTED_LOCATION_DEBUG)
+        get_target_property(ZLIB_ANY_LOCATION ZLIB::ZLIB IMPORTED_LOCATION)
+        if (ZLIB_RELEASE_LOCATION)
+            cmake_path(SET ZLIB_RELEASE_LOCATION "${ZLIB_RELEASE_LOCATION}")
+            cmake_path(GET ZLIB_RELEASE_LOCATION PARENT_PATH ZLIB_RELEASE_LOCATION)
+            cmake_path(SET ZLIB_RELEASE_LOCATION NORMALIZE "${ZLIB_RELEASE_LOCATION}/../bin")
+            find_file(ZLIB_DLL_REL ${ZLIB_NAMES_LIST} PATHS "${ZLIB_RELEASE_LOCATION}" DOC "ZLIB::ZLIB DLL path (Release)" REQUIRED
+                NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+            )
+        endif()
+        if (ZLIB_DEBUG_LOCATION)
+            cmake_path(SET ZLIB_DEBUG_LOCATION "${ZLIB_DEBUG_LOCATION}")
+            cmake_path(GET ZLIB_DEBUG_LOCATION PARENT_PATH ZLIB_DEBUG_LOCATION)
+            cmake_path(SET ZLIB_DEBUG_LOCATION NORMALIZE "${ZLIB_DEBUG_LOCATION}/../bin")
+            find_file(ZLIB_DLL_DBG ${ZLIB_NAMES_LIST} PATHS "${ZLIB_DEBUG_LOCATION}" DOC "ZLIB::ZLIB DLL path (Debug)" REQUIRED
+                NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+            )
+        endif()
+        if (ZLIB_ANY_LOCATION)
+            cmake_path(SET ZLIB_ANY_LOCATION "${ZLIB_ANY_LOCATION}")
+            cmake_path(GET ZLIB_ANY_LOCATION PARENT_PATH ZLIB_ANY_LOCATION)
+            cmake_path(SET ZLIB_ANY_LOCATION NORMALIZE "${ZLIB_ANY_LOCATION}/../bin")
+            find_file(ZLIB_DLL_ANY ${ZLIB_NAMES_LIST} PATHS "${ZLIB_ANY_LOCATION}" DOC "ZLIB::ZLIB DLL path (any)" REQUIRED
+                NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+            )
+            set(ZLIB_DLL_REL "${ZLIB_DLL_ANY}")
+            set(ZLIB_DLL_DBG "${ZLIB_DLL_ANY}")
+        endif()
+
+        add_custom_command(TARGET qbt_app POST_BUILD
+            COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "$<IF:$<CONFIG:Debug>,${ZLIB_DLL_DBG},${ZLIB_DLL_REL}>"
+            "${OPENSSL_LIBCRYPTO_DLL}"
+            "${OPENSSL_LIBSSL_DLL}"
+            "$<TARGET_FILE:LibtorrentRasterbar::torrent-rasterbar>"
+            "$<TARGET_FILE_DIR:qbt_app>"
+        )
+
+        list(APPEND WINDEPLOYQT_OPTIONS_LIST "--verbose" "0")
+        add_custom_command(TARGET qbt_app POST_BUILD
+            COMMAND Qt6::windeployqt ${WINDEPLOYQT_OPTIONS_LIST} "$<TARGET_FILE:qbt_app>"
+            COMMENT "Run windeployqt after build"
+        )
+    endif()
 endif()
 
 # Additional feature dependent configuration
@@ -139,14 +203,18 @@ endif()
 if (GUI)
     target_link_libraries(qbt_app PRIVATE qbt_gui)
     if ((CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-        qt_import_plugins(qbt_app INCLUDE Qt6::QSvgIconPlugin Qt6::QSvgPlugin)
+        get_target_property(_QT_LIB_TYPE Qt6::Core TYPE)
+        if (_QT_LIB_TYPE STREQUAL "STATIC_LIBRARY")
+            # this does nothing on non-static builds, but would still print an unecessary warning
+            qt_import_plugins(qbt_app INCLUDE Qt6::QSvgIconPlugin Qt6::QSvgPlugin)
+        endif()
     endif()
 endif()
 
 if (WEBUI)
     target_sources(qbt_app PRIVATE
-        ${QBT_WEBUI_QM_FILES}
-        ${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc # yes, it's supposed to be "*_BINARY_DIR"
+        ${QBT_WEBUI_QM_FILES_LIST}
+        "${qBittorrent_BINARY_DIR}/src/webui/www/translations/webui_translations.qrc" # yes, it's supposed to be "*_BINARY_DIR"
     )
     target_link_libraries(qbt_app PRIVATE qbt_webui)
 endif()
@@ -154,15 +222,30 @@ endif()
 # Installation
 # -----------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
+# On Windows, everything goes in the base install location
+
 install(TARGETS qbt_app
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    BUNDLE  DESTINATION .
+    RUNTIME DESTINATION "$<IF:$<BOOL:${WIN32}>,.,${CMAKE_INSTALL_BINDIR}>"
+    BUNDLE  DESTINATION "."
     COMPONENT runtime
 )
 
+# TODO: works for MSVC, what about MinGW?
 if (MSVC)
     install(FILES $<TARGET_PDB_FILE:qbt_app>
-        DESTINATION ${CMAKE_INSTALL_BINDIR}
+        DESTINATION "."
+        COMPONENT runtime
         OPTIONAL
     )
+    if (MSVC_RUNTIME_DYNAMIC)
+        install(
+            DIRECTORY "${CMAKE_BINARY_DIR}/" # trailing slash is required here to copy only the contents
+            DESTINATION "."
+            COMPONENT runtime
+            FILES_MATCHING REGEX ".*.dll|.*.qm"
+            # the exclusion below is required to prevent creation of empty directories at the destination
+            # see https://gitlab.kitware.com/cmake/cmake/-/issues/19189
+            REGEX "CMakeFiles.*|dist.*|src.*" EXCLUDE
+        )
+    endif()
 endif()

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -559,7 +559,7 @@ void Application::processParams(const QStringList &params)
 
         if (param.startsWith(QLatin1String("@addPaused=")))
         {
-            torrentParams.addPaused = (param.midRef(11).toInt() != 0);
+            torrentParams.addPaused = (QStringView(param).mid(11).toInt() != 0);
             continue;
         }
 
@@ -589,7 +589,7 @@ void Application::processParams(const QStringList &params)
 
         if (param.startsWith(QLatin1String("@skipDialog=")))
         {
-            skipTorrentDialog = (param.midRef(12).toInt() != 0);
+            skipTorrentDialog = (QStringView(param).mid(12).toInt() != 0);
             continue;
         }
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -176,7 +176,7 @@ target_link_libraries(qbt_base
         ZLIB::ZLIB
     PUBLIC
         LibtorrentRasterbar::torrent-rasterbar
-        Qt5::Core Qt5::Network Qt5::Sql Qt5::Xml
+        Qt6::Core Qt6::Network Qt6::Sql Qt6::Xml
         qbt_common_cfg
 )
 
@@ -203,5 +203,5 @@ if (NOT WEBUI)
 endif()
 
 if (DBUS)
-    target_link_libraries(qbt_base PUBLIC Qt5::DBus)
+    target_link_libraries(qbt_base PUBLIC Qt6::DBus)
 endif()

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -186,9 +186,9 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_library(AppKit_LIBRARY AppKit)
 
     target_link_libraries(qbt_base PRIVATE
-        ${AppKit_LIBRARY}
-        ${Carbon_LIBRARY}
-        ${IOKit_LIBRARY}
+        "${AppKit_LIBRARY}"
+        "${Carbon_LIBRARY}"
+        "${IOKit_LIBRARY}"
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(qbt_base PRIVATE Iphlpapi)

--- a/src/base/bittorrent/peeraddress.cpp
+++ b/src/base/bittorrent/peeraddress.cpp
@@ -32,18 +32,18 @@
 
 using namespace BitTorrent;
 
-PeerAddress PeerAddress::parse(const QString &address)
+PeerAddress PeerAddress::parse(const QStringView address)
 {
-    QVector<QStringRef> ipPort;
+    QVector<QStringView> ipPort;
 
-    if (address.startsWith('[') && address.contains("]:"))
+    if (address.startsWith(QLatin1Char {'['}) && address.contains(QLatin1String {"]:"}))
     {  // IPv6
-        ipPort = address.splitRef("]:");
+        ipPort = address.split(QString::fromLatin1("]:"));
         ipPort[0] = ipPort[0].mid(1);  // chop '['
     }
-    else if (address.contains(':'))
+    else if (address.contains(QLatin1Char {':'}))
     {  // IPv4
-        ipPort = address.splitRef(':');
+        ipPort = address.split(QLatin1Char {':'});
     }
     else
     {

--- a/src/base/bittorrent/peeraddress.h
+++ b/src/base/bittorrent/peeraddress.h
@@ -39,7 +39,7 @@ namespace BitTorrent
         QHostAddress ip;
         ushort port = 0;
 
-        static PeerAddress parse(const QString &address);
+        static PeerAddress parse(QStringView address);
         QString toString() const;
     };
 

--- a/src/base/bittorrent/session.cpp
+++ b/src/base/bittorrent/session.cpp
@@ -1594,7 +1594,7 @@ void Session::populateAdditionalTrackers()
     m_additionalTrackerList.clear();
 
     const QString trackers = additionalTrackers();
-    for (QStringRef tracker : asConst(trackers.splitRef('\n')))
+    for (QStringView tracker : asConst(QStringView(trackers).split(QLatin1Char {'\n'})))
     {
         tracker = tracker.trimmed();
         if (!tracker.isEmpty())

--- a/src/base/bittorrent/torrentimpl.cpp
+++ b/src/base/bittorrent/torrentimpl.cpp
@@ -1865,9 +1865,9 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
     if (m_oldPath[p->index].isEmpty())
         m_oldPath.remove(p->index);
 
-    QVector<QStringRef> oldPathParts = oldFilePath.splitRef('/', Qt::SkipEmptyParts);
+    QVector<QStringView> oldPathParts = QStringView(oldFilePath).split('/', Qt::SkipEmptyParts);
     oldPathParts.removeLast();  // drop file name part
-    QVector<QStringRef> newPathParts = newFilePath.splitRef('/', Qt::SkipEmptyParts);
+    QVector<QStringView> newPathParts = QStringView(newFilePath).split('/', Qt::SkipEmptyParts);
     newPathParts.removeLast();  // drop file name part
 
 #if defined(Q_OS_WIN)
@@ -1886,7 +1886,7 @@ void TorrentImpl::handleFileRenamedAlert(const lt::file_renamed_alert *p)
 
     for (int i = (oldPathParts.size() - 1); i >= pathIdx; --i)
     {
-        QDir().rmdir(savePath() + Utils::String::join(oldPathParts, QLatin1String("/")));
+        QDir().rmdir(savePath() + Utils::String::join(oldPathParts, QString::fromLatin1("/")));
         oldPathParts.removeLast();
     }
 

--- a/src/base/bittorrent/torrentinfo.cpp
+++ b/src/base/bittorrent/torrentinfo.cpp
@@ -61,7 +61,7 @@ namespace
         {
             if (QDir::isAbsolutePath(filePath)) continue;
 
-            const auto filePathElements = filePath.splitRef('/');
+            const auto filePathElements = QStringView(filePath).split(u'/');
             // if at least one file has no root folder, no common root folder exists
             if (filePathElements.count() <= 1) return {};
 

--- a/src/base/http/connection.cpp
+++ b/src/base/http/connection.cpp
@@ -137,9 +137,9 @@ bool Connection::acceptsGzipEncoding(QString codings)
 {
     // [rfc7231] 5.3.4. Accept-Encoding
 
-    const auto isCodingAvailable = [](const QVector<QStringRef> &list, const QString &encoding) -> bool
+    const auto isCodingAvailable = [](const QVector<QStringView> &list, const QStringView encoding) -> bool
     {
-        for (const QStringRef &str : list)
+        for (const QStringView &str : list)
         {
             if (!str.startsWith(encoding))
                 continue;
@@ -149,7 +149,7 @@ bool Connection::acceptsGzipEncoding(QString codings)
                 return true;
 
             // [rfc7231] 5.3.1. Quality Values
-            const QStringRef substr = str.mid(encoding.size() + 3);  // ex. skip over "gzip;q="
+            const QStringView substr = str.mid(encoding.size() + 3);  // ex. skip over "gzip;q="
 
             bool ok = false;
             const double qvalue = substr.toDouble(&ok);
@@ -161,15 +161,15 @@ bool Connection::acceptsGzipEncoding(QString codings)
         return false;
     };
 
-    const QVector<QStringRef> list = codings.remove(' ').remove('\t').splitRef(',', Qt::SkipEmptyParts);
+    const QVector<QStringView> list = QStringView(codings.remove(' ').remove('\t')).split(QChar::fromLatin1(','), Qt::SkipEmptyParts);
     if (list.isEmpty())
         return false;
 
-    const bool canGzip = isCodingAvailable(list, QLatin1String("gzip"));
+    const bool canGzip = isCodingAvailable(list, QString::fromLatin1("gzip"));
     if (canGzip)
         return true;
 
-    const bool canAny = isCodingAvailable(list, QLatin1String("*"));
+    const bool canAny = isCodingAvailable(list, QString::fromLatin1("*"));
     if (canAny)
         return true;
 

--- a/src/base/http/requestparser.cpp
+++ b/src/base/http/requestparser.cpp
@@ -57,7 +57,7 @@ namespace
         return in;
     }
 
-    bool parseHeaderLine(const QString &line, HeaderMap &out)
+    bool parseHeaderLine(const QStringView line, HeaderMap &out)
     {
         // [rfc7230] 3.2. Header Fields
         const int i = line.indexOf(':');
@@ -67,8 +67,8 @@ namespace
             return false;
         }
 
-        const QString name = line.leftRef(i).trimmed().toString().toLower();
-        const QString value = line.midRef(i + 1).trimmed().toString();
+        const QString name = line.left(i).trimmed().toString().toLower();
+        const QString value = line.mid(i + 1).trimmed().toString();
         out[name] = value;
 
         return true;
@@ -145,10 +145,10 @@ RequestParser::ParseResult RequestParser::doParse(const QByteArray &data)
     return {ParseStatus::BadRequest, Request(), 0};  // TODO: SHOULD respond "501 Not Implemented"
 }
 
-bool RequestParser::parseStartLines(const QString &data)
+bool RequestParser::parseStartLines(const QStringView data)
 {
     // we don't handle malformed request which uses `LF` for newline
-    const QVector<QStringRef> lines = data.splitRef(CRLF, Qt::SkipEmptyParts);
+    const QVector<QStringView> lines = data.split(QString::fromLatin1(CRLF), Qt::SkipEmptyParts);
 
     // [rfc7230] 3.2.2. Field Order
     QStringList requestLines;
@@ -267,7 +267,7 @@ bool RequestParser::parsePostMessage(const QByteArray &data)
             return false;
         }
 
-        const QByteArray delimiter = Utils::String::unquote(contentType.midRef(idx + boundaryFieldName.size())).toLatin1();
+        const QByteArray delimiter = Utils::String::unquote(QStringView(contentType).mid(idx + boundaryFieldName.size())).toLatin1();
         if (delimiter.isEmpty())
         {
             qWarning() << Q_FUNC_INFO << "boundary delimiter field empty!";
@@ -311,13 +311,13 @@ bool RequestParser::parseFormData(const QByteArray &data)
     const QByteArray payload = viewWithoutEndingWith(list[1], CRLF);
 
     HeaderMap headersMap;
-    const QVector<QStringRef> headerLines = headers.splitRef(CRLF, Qt::SkipEmptyParts);
+    const QVector<QStringView> headerLines = QStringView(headers).split(QString::fromLatin1(CRLF), Qt::SkipEmptyParts);
     for (const auto &line : headerLines)
     {
-        if (line.trimmed().startsWith(HEADER_CONTENT_DISPOSITION, Qt::CaseInsensitive))
+        if (line.trimmed().startsWith(QString::fromLatin1(HEADER_CONTENT_DISPOSITION), Qt::CaseInsensitive))
         {
             // extract out filename & name
-            const QVector<QStringRef> directives = line.split(';', Qt::SkipEmptyParts);
+            const QVector<QStringView> directives = line.split(u';', Qt::SkipEmptyParts);
 
             for (const auto &directive : directives)
             {

--- a/src/base/http/requestparser.h
+++ b/src/base/http/requestparser.h
@@ -60,7 +60,7 @@ namespace Http
         RequestParser();
 
         ParseResult doParse(const QByteArray &data);
-        bool parseStartLines(const QString &data);
+        bool parseStartLines(QStringView data);
         bool parseRequestLine(const QString &line);
 
         bool parsePostMessage(const QByteArray &data);

--- a/src/base/rss/rss_autodownloadrule.cpp
+++ b/src/base/rss/rss_autodownloadrule.cpp
@@ -325,7 +325,7 @@ bool AutoDownloadRule::matchesEpisodeFilterExpression(const QString &articleTitl
 
                 if (episode.endsWith('-'))
                 { // Infinite range
-                    const int episodeOurs {episode.leftRef(episode.size() - 1).toInt()};
+                    const int episodeOurs {QStringView(episode).left(episode.size() - 1).toInt()};
                     if (((seasonTheirs == seasonOurs) && (episodeTheirs >= episodeOurs)) || (seasonTheirs > seasonOurs))
                         return true;
                 }

--- a/src/base/search/searchdownloadhandler.cpp
+++ b/src/base/search/searchdownloadhandler.cpp
@@ -59,7 +59,7 @@ void SearchDownloadHandler::downloadProcessFinished(int exitcode)
     if ((exitcode == 0) && (m_downloadProcess->exitStatus() == QProcess::NormalExit))
     {
         const QString line = QString::fromUtf8(m_downloadProcess->readAllStandardOutput()).trimmed();
-        const QVector<QStringRef> parts = line.splitRef(' ');
+        const QVector<QStringView> parts = QStringView(line).split(u' ');
         if (parts.size() == 2)
             path = parts[0].toString();
     }

--- a/src/base/search/searchhandler.cpp
+++ b/src/base/search/searchhandler.cpp
@@ -163,9 +163,9 @@ void SearchHandler::processFailed()
 // Parse one line of search results list
 // Line is in the following form:
 // file url | file name | file size | nb seeds | nb leechers | Search engine url
-bool SearchHandler::parseSearchResult(const QString &line, SearchResult &searchResult)
+bool SearchHandler::parseSearchResult(const QStringView line, SearchResult &searchResult)
 {
-    const QVector<QStringRef> parts = line.splitRef('|');
+    const QVector<QStringView> parts = line.split(u'|');
     const int nbFields = parts.size();
 
     if (nbFields < (NB_PLUGIN_COLUMNS - 1)) return false; // -1 because desc_link is optional

--- a/src/base/search/searchhandler.h
+++ b/src/base/search/searchhandler.h
@@ -78,7 +78,7 @@ private:
     void readSearchOutput();
     void processFailed();
     void processFinished(int exitcode);
-    bool parseSearchResult(const QString &line, SearchResult &searchResult);
+    bool parseSearchResult(QStringView line, SearchResult &searchResult);
 
     const QString m_pattern;
     const QString m_category;

--- a/src/base/utils/bytearray.h
+++ b/src/base/utils/bytearray.h
@@ -28,14 +28,14 @@
 
 #pragma once
 
-#include <QString>
+#include <Qt>
 #include <QtContainerFwd>
 
 class QByteArray;
 
 namespace Utils::ByteArray
 {
-    // Mimic QString::splitRef(sep, behavior)
+    // Mimic QStringView(in).split(sep, behavior)
     QVector<QByteArray> splitToViews(const QByteArray &in, const QByteArray &sep, const Qt::SplitBehavior behavior = Qt::KeepEmptyParts);
 
     // Mimic QByteArray::mid(pos, len) but instead of returning a full-copy,

--- a/src/base/utils/compare.cpp
+++ b/src/base/utils/compare.cpp
@@ -60,16 +60,16 @@ int Utils::Compare::naturalCompare(const QString &left, const QString &right, co
         {
             // Both are digits, compare the numbers
 
-            const auto numberView = [](const QString &str, int &pos) -> QStringRef
+            const auto numberView = [](const QStringView str, int &pos) -> QStringView
             {
                 const int start = pos;
                 while ((pos < str.size()) && str[pos].isDigit())
                     ++pos;
-                return str.midRef(start, (pos - start));
+                return str.mid(start, (pos - start));
             };
 
-            const QStringRef numViewL = numberView(left, posL);
-            const QStringRef numViewR = numberView(right, posR);
+            const QStringView numViewL = numberView(left, posL);
+            const QStringView numViewR = numberView(right, posR);
 
             if (numViewL.length() != numViewR.length())
                 return (numViewL.length() - numViewR.length());

--- a/src/base/utils/misc.cpp
+++ b/src/base/utils/misc.cpp
@@ -498,7 +498,7 @@ QString Utils::Misc::opensslVersionString()
 #else
     static const auto version {QString::fromLatin1(SSLeay_version(SSLEAY_VERSION))};
 #endif
-    return version.splitRef(' ', Qt::SkipEmptyParts)[1].toString();
+    return QStringView(version).split(u' ', Qt::SkipEmptyParts)[1].toString();
 }
 
 QString Utils::Misc::zlibVersionString()

--- a/src/base/utils/string.cpp
+++ b/src/base/utils/string.cpp
@@ -43,7 +43,7 @@
 // to send numbers instead of strings with suffixes
 QString Utils::String::fromDouble(const double n, const int precision)
 {
-    /* HACK because QString rounds up. Eg QString::number(0.999*100.0, 'f' ,1) == 99.9
+    /* HACK because QString rounds up. Eg QString::number(0.999*100.0, 'f', 1) == 99.9
     ** but QString::number(0.9999*100.0, 'f' ,1) == 100.0 The problem manifests when
     ** the number has more digits after the decimal than we want AND the digit after
     ** our 'wanted' is >= 5. In this case our last digit gets rounded up. So for each
@@ -99,7 +99,7 @@ std::optional<double> Utils::String::parseDouble(const QString &string)
     return std::nullopt;
 }
 
-QString Utils::String::join(const QVector<QStringRef> &strings, const QString &separator)
+QString Utils::String::join(const QVector<QStringView> &strings, const QStringView separator)
 {
     if (strings.empty())
         return {};

--- a/src/base/utils/string.h
+++ b/src/base/utils/string.h
@@ -37,8 +37,6 @@
 #include <Qt>
 #include <QtContainerFwd>
 
-class QStringRef;
-
 namespace Utils::String
 {
     QString wildcardToRegexPattern(const QString &pattern);
@@ -61,7 +59,7 @@ namespace Utils::String
     std::optional<int> parseInt(const QString &string);
     std::optional<double> parseDouble(const QString &string);
 
-    QString join(const QVector<QStringRef> &strings, const QString &separator);
+    QString join(const QVector<QStringView> &strings, QStringView separator);
 
     QString fromDouble(double n, int precision);
 

--- a/src/base/version.h.in
+++ b/src/base/version.h.in
@@ -28,8 +28,8 @@
 
 #pragma once
 
-#define QBT_VERSION_MAJOR 4
-#define QBT_VERSION_MINOR 4
+#define QBT_VERSION_MAJOR 5
+#define QBT_VERSION_MINOR 0
 #define QBT_VERSION_BUGFIX 0
 #define QBT_VERSION_BUILD 0
 #define QBT_VERSION_STATUS "alpha1"  // Should be empty for stable releases!

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -199,7 +199,7 @@ target_link_libraries(qbt_gui
     PRIVATE
         qbt_base
     PUBLIC
-        Qt5::Gui Qt5::Widgets
+        Qt6::Gui Qt6::Widgets
 )
 
 if (DBUS)
@@ -219,10 +219,7 @@ if ((CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "Darwi
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_link_libraries(qbt_gui PRIVATE
-        Qt5::WinExtras
-        PowrProf
-    )
+    target_link_libraries(qbt_gui PRIVATE PowrProf)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -230,7 +227,5 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         macutilities.h
         macutilities.mm
     )
-    target_link_libraries(qbt_gui PRIVATE
-        objc
-    )
+    target_link_libraries(qbt_gui PRIVATE objc)
 endif()

--- a/src/gui/downloadfromurldialog.cpp
+++ b/src/gui/downloadfromurldialog.cpp
@@ -71,10 +71,10 @@ DownloadFromURLDialog::DownloadFromURLDialog(QWidget *parent)
 
     // Paste clipboard if there is an URL in it
     const QString clipboardText = qApp->clipboard()->text();
-    const QVector<QStringRef> clipboardList = clipboardText.splitRef('\n');
+    const QVector<QStringView> clipboardList = QStringView(clipboardText).split(u'\n');
 
     QSet<QString> uniqueURLs;
-    for (QStringRef strRef : clipboardList)
+    for (QStringView strRef : clipboardList)
     {
         strRef = strRef.trimmed();
         if (strRef.isEmpty()) continue;
@@ -103,10 +103,10 @@ DownloadFromURLDialog::~DownloadFromURLDialog()
 void DownloadFromURLDialog::downloadButtonClicked()
 {
     const QString plainText = m_ui->textUrls->toPlainText();
-    const QVector<QStringRef> urls = plainText.splitRef('\n');
+    const QVector<QStringView> urls = QStringView(plainText).split(u'\n');
 
     QSet<QString> uniqueURLs;
-    for (QStringRef url : urls)
+    for (QStringView url : urls)
     {
         url = url.trimmed();
         if (url.isEmpty()) continue;

--- a/src/gui/fspathedit_p.h
+++ b/src/gui/fspathedit_p.h
@@ -39,7 +39,6 @@ class QCompleter;
 class QContextMenuEvent;
 class QFileSystemModel;
 class QKeyEvent;
-class QStringRef;
 
 namespace Private
 {
@@ -82,10 +81,10 @@ namespace Private
         QString lastTestedPath() const;
 
     private:
-        QValidator::State validate(const QString &path, const QVector<QStringRef> &pathComponents, bool strict,
+        QValidator::State validate(const QVector<QStringView> &pathComponents, bool strict,
                                    int firstComponentToTest, int lastComponentToTest) const;
 
-        TestResult testPath(const QStringRef &path, bool pathIsComplete) const;
+        TestResult testPath(QStringView path, bool pathIsComplete) const;
 
         bool m_strictMode;
         bool m_existingOnly;

--- a/src/gui/properties/trackersadditiondialog.cpp
+++ b/src/gui/properties/trackersadditiondialog.cpp
@@ -59,7 +59,7 @@ QStringList TrackersAdditionDialog::newTrackers() const
     const QString plainText = m_ui->textEditTrackersList->toPlainText();
 
     QStringList cleanTrackers;
-    for (QStringRef url : asConst(plainText.splitRef('\n')))
+    for (QStringView url : asConst(QStringView(plainText).split(u'\n')))
     {
         url = url.trimmed();
         if (!url.isEmpty())

--- a/src/gui/torrentcontentmodel.cpp
+++ b/src/gui/torrentcontentmodel.cpp
@@ -503,16 +503,16 @@ void TorrentContentModel::setupModelData(const BitTorrent::TorrentInfo &info)
         const QString path = Utils::Fs::toUniformPath(info.filePath(i));
 
         // Iterate of parts of the path to create necessary folders
-        QVector<QStringRef> pathFolders = path.splitRef('/', Qt::SkipEmptyParts);
+        QVector<QStringView> pathFolders = QStringView(path).split(u'/', Qt::SkipEmptyParts);
         pathFolders.removeLast();
 
-        for (const QStringRef &pathPartRef : asConst(pathFolders))
+        for (const QStringView pathPart : asConst(pathFolders))
         {
-            const QString pathPart = pathPartRef.toString();
-            TorrentContentModelFolder *newParent = currentParent->childFolderWithName(pathPart);
+            const QString folderPath = pathPart.toString();
+            TorrentContentModelFolder *newParent = currentParent->childFolderWithName(folderPath);
             if (!newParent)
             {
-                newParent = new TorrentContentModelFolder(pathPart, currentParent);
+                newParent = new TorrentContentModelFolder(folderPath, currentParent);
                 currentParent->appendChild(newParent);
             }
             currentParent = newParent;

--- a/src/gui/trackerentriesdialog.cpp
+++ b/src/gui/trackerentriesdialog.cpp
@@ -81,13 +81,13 @@ void TrackerEntriesDialog::setTrackers(const QVector<BitTorrent::TrackerEntry> &
 QVector<BitTorrent::TrackerEntry> TrackerEntriesDialog::trackers() const
 {
     const QString plainText = m_ui->plainTextEdit->toPlainText();
-    const QVector<QStringRef> lines = plainText.splitRef('\n');
+    const QVector<QStringView> lines = QStringView(plainText).split(u'\n');
 
     QVector<BitTorrent::TrackerEntry> entries;
     entries.reserve(lines.size());
 
     int tier = 0;
-    for (QStringRef line : lines)
+    for (QStringView line : lines)
     {
         line = line.trimmed();
 

--- a/src/webui/webapplication.cpp
+++ b/src/webui/webapplication.cpp
@@ -72,11 +72,11 @@ const QString PRIVATE_FOLDER {QStringLiteral("/private")};
 
 namespace
 {
-    QStringMap parseCookie(const QString &cookieStr)
+    QStringMap parseCookie(const QStringView cookieStr)
     {
         // [rfc6265] 4.2.1. Syntax
         QStringMap ret;
-        const QVector<QStringRef> cookies = cookieStr.splitRef(';', Qt::SkipEmptyParts);
+        const QVector<QStringView> cookies = cookieStr.split(u';', Qt::SkipEmptyParts);
 
         for (const auto &cookie : cookies)
         {
@@ -386,10 +386,10 @@ void WebApplication::configure()
 
     if (pref->isWebUICustomHTTPHeadersEnabled())
     {
-        const QString customHeaders = pref->getWebUICustomHTTPHeaders().trimmed();
-        const QVector<QStringRef> customHeaderLines = customHeaders.splitRef('\n', Qt::SkipEmptyParts);
+        const QString customHeaders = pref->getWebUICustomHTTPHeaders();
+        const QVector<QStringView> customHeaderLines = QStringView(customHeaders).trimmed().split(u'\n', Qt::SkipEmptyParts);
 
-        for (const QStringRef &line : customHeaderLines)
+        for (const QStringView line : customHeaderLines)
         {
             const int idx = line.indexOf(':');
             if (idx < 0)


### PR DESCRIPTION
Further explanation about this PR at the bottom. Commit summary:

```
Subject: [PATCH 1/2] Multiple fixes for building with Qt6 on Windows

This was tested with the experimental vcpkg Qt6 port:
microsoft/vcpkg#14333
as well as with the official Qt6 MSVC binary distribution

Working with upstream on the vcpkg port of Qt6 is the priority since
that is what will be used in CI.

What works:

- Dynamic and static Debug and Release builds on MSVC with vcpkg.
In all 4 cases, installation works correctly, as well as running from the
build directory right after the build.

- Dynamic Release and Debug builds on MSVC without vcpkg (using zlib,
  boost and libtorrent compiled from source + qt and openssl precompiled
  binaries from the official MSVC Qt distribution). Again, running from
  the build directory and installing works.

Current issues when building with the vcpkg Qt6 port:

- The problem with CMAKE_FIND_PACKAGE_PREFER_CONFIG (marked with a TODO)
has been reported to Qt: https://bugreports.qt.io/browse/QTBUG-93604
The workaround is trivial (just commented out a single line) and
harmless for now.

What was not tested/touched:

- Building with MinGW
- Static builds without vcpkg

Minor changes:

- Bumped minimum Qt version to 6.1.0
- Bumped minimum CMake version to 3.20 due to usage of cmake_path()
- The Qt6 Tools component is required for the Qt6::windeployqt target
```

---

```
Subject: [PATCH 2/2] add experimental workflow for Qt6 builds

also tests installation on Windows with dynamic and static builds
```

---

---

---
 
This is not really intended to be merged. I just posted this for convenience, so that you are also able to test more easily and so that I could test the CI runs.

~I will probably try to backport some of these improvements to the current Qt5 build (namely the installation and handling of dependent DLLs for dynamic builds).~ In progress: https://github.com/qbittorrent/qBittorrent/pull/14959

It's easy to test with vcpkg if you want to. As for building with the official Qt6 MSVC binary distribution + other dependencies compiled from source, here are the steps I preformed, if you want to reproduce.

This can be a bit simplified by installing most/all binaries under a common prefix and then just setting `CMAKE_PREFIX_PATH` appropriately; it was just more convenient for me at the time to install everything to separate prefixes. One notable annoyance is that Qt6 requires setting more variables than Qt5 in order to work, but it's not too bad - if you miss any, CMake will tell you exactly what it needs.

Boost 1.76.0 (builds both `Release` and `Debug` artifacts):

```txt
.\bootstrap.bat --prefix=installed
.\b2.exe address-model=64 --build-type=complete --build-dir=build install --prefix=installed -a -q -j4
```

`zlib` (`Release`):

```txt
cd "C:\Users\User\source\deps_msvc\zlib-1.2.11"
cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\msvc\zlib-1.2.11\build\installed"
cmake --build build
cmake --install build
```

`zlib` (`Debug`):

```txt
cd "C:\Users\User\source\deps_msvc\zlib-1.2.11"
cmake -S . -B build_dbg -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\deps_msvc\zlib-1.2.11\installed_dbg"
cmake --build build_dbg
cmake --install build_dbg
```

Everything else below uses pre-compiled Qt and OpenSSL binaries from the official Qt binary distribution, and are assumed to be installed under `C:\Qt`.

`libtorrent` (`Release`):

```txt
cd "C:\Users\User\source\deps_msvc\libtorrent"
git checkout RC_1_2
mkdir cmake-build-dir
mkdir RC_1_2

cmake -S . -B cmake-build-dir\RC_1_2 -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR="C:\Qt\Tools\OpenSSL\Win_x64" -DBoost_DIR="C:\Users\User\source\deps_msvc\boost_1_76_0\installed\lib\cmake\Boost-1.76.0" -Ddeprecated-functions=OFF -Dbuild_examples=ON -Dbuild_tools=ON -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\deps_msvc\libtorrent\cmake-build-dir\RC_1_2_installed"

cmake --build cmake-build-dir\RC_1_2
cmake --install cmake-build-dir\RC_1_2
```

`libtorrent` (`Debug`):

```txt
cd "C:\Users\User\source\deps_msvc\libtorrent"
git checkout RC_1_2
mkdir cmake-build-dir
mkdir RC_1_2_dbg

cmake -S . -B cmake-build-dir\RC_1_2_dbg -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR="C:\Qt\Tools\OpenSSL\Win_x64" -DBoost_DIR="C:\Users\User\source\deps_msvc\boost_1_76_0\installed\lib\cmake\Boost-1.76.0" -Ddeprecated-functions=OFF -Dbuild_examples=ON -Dbuild_tools=ON -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\deps_msvc\libtorrent\cmake-build-dir\RC_1_2_installed_dbg"

cmake --build cmake-build-dir\RC_1_2_dbg
cmake --install cmake-build-dir\RC_1_2_dbg
```

qBittorrent with Qt6 (`Release`):

```txt
cd "C:\Users\User\source\qt6-temp\qBittorrent"

cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE="Release" -DZLIB_INCLUDE_DIR="C:\Users\User\source\deps_msvc\zlib-1.2.11\installed\include" -DZLIB_LIBRARY="C:\Users\User\source\deps_msvc\zlib-1.2.11\installed\lib\zlib.lib" -DOPENSSL_ROOT_DIR="C:\Qt\Tools\OpenSSL\Win_x64" -DBoost_DIR="C:\Users\User\source\deps_msvc\boost_1_76_0\installed\lib\cmake\Boost-1.76.0" -DLibtorrentRasterbar_DIR="C:\Users\User\source\deps_msvc\libtorrent\cmake-build-dir\RC_1_2_installed\lib\cmake\LibtorrentRasterbar" -DQt6_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6" -DQt6CoreTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6CoreTools" -DQt6ToolsTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6ToolsTools" -DQt6WidgetsTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6WidgetsTools" -DQt6GuiTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6GuiTools" -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\qt6-temp\qBittorrent\install_dir"

cmake --build build
cmake --install build
```

qBittorrent with Qt6 (`Debug`):

```txt
cd "C:\Users\User\source\qt6-temp\qBittorrent"

cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE="Debug" -DZLIB_INCLUDE_DIR="C:\Users\User\source\deps_msvc\zlib-1.2.11\installed_dbg\include" -DZLIB_LIBRARY="C:\Users\User\source\deps_msvc\zlib-1.2.11\installed_dbg\lib\zlibd.lib" -DOPENSSL_ROOT_DIR="C:\Qt\Tools\OpenSSL\Win_x64" -DBoost_DIR="C:\Users\User\source\deps_msvc\boost_1_76_0\installed\lib\cmake\Boost-1.76.0" -DLibtorrentRasterbar_DIR="C:\Users\User\source\deps_msvc\libtorrent\cmake-build-dir\RC_1_2_installed_dbg\lib\cmake\LibtorrentRasterbar" -DQt6_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6" -DQt6CoreTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6CoreTools" -DQt6ToolsTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6ToolsTools" -DQt6WidgetsTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6WidgetsTools" -DQt6GuiTools_DIR="C:\Qt\6.1.0\msvc2019_64\lib\cmake\Qt6GuiTools" -DCMAKE_INSTALL_PREFIX="C:\Users\User\source\qt6-temp\qBittorrent\install_dir_dbg"

cmake --build build
cmake --install build --prefix install_dir
```
