### PR TITLE
CI: Use Qt 5.15.2 from third-party PPA on Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,12 +42,12 @@ jobs:
           libboost-dev libboost-chrono-dev libboost-random-dev libboost-system-dev
       # sudo apt install libqt5svg5-dev qtbase5-dev qttools5-dev # the Qt version in the standard repositories is too old...
 
-    # this will be installed under /opt/qt514. CMake will still find it automatically without additional hints
-    # to speed up the process, only the required components are installed rather than the full qt514-meta-full metapackage
-    - name: install Qt 5.14.2 from an external PPA
+    # this will be installed under /opt/qt515. CMake will still find it automatically without additional hints
+    # to speed up the process, only the required components are installed rather than the full qt515-meta-full metapackage
+    - name: install Qt 5.15.2 from an external PPA
       run: |
-        sudo add-apt-repository ppa:beineri/opt-qt-5.14.2-focal
-        sudo apt install qt514base qt514svg qt514tools
+        sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
+        sudo apt install qt515base qt515svg qt515tools
 
     - name: install libtorrent from source
       run: |


### PR DESCRIPTION
As requested in https://github.com/qbittorrent/qBittorrent/pull/15181#issuecomment-878352195.